### PR TITLE
feat: bidirectional zone browse without upstream InputPatches conflicts

### DIFF
--- a/Handlers/DuelHandler.cs
+++ b/Handlers/DuelHandler.cs
@@ -82,15 +82,90 @@ namespace BlindDuel
                             }
                         }
                         catch (Exception ex) { Log.Write($"[DuelHandler] ListCard read: {ex.Message}"); }
-                    }
 
-                    // No ListCard (cancel/confirm button) — reset card dedup so
-                    // navigating back to a card re-reads it.
-                    _lastSelButton = null;
-                    return null;
+                        // m_CardData empty — fall through to zone browse fallback below
+                    }
+                    else
+                    {
+                        // No ListCard (cancel/confirm button) — reset card dedup so
+                        // navigating back to a card re-reads it.
+                        _lastSelButton = null;
+                        return null;
+                    }
                 }
             }
             catch (Exception ex) { Log.Write($"[DuelHandler] CardSelection: {ex.Message}"); }
+
+            // Zone browse fallback (Graveyard, Extra Deck, Banished opened with X).
+            // Uses a running counter (DuelState.BrowseIndex) adjusted by BrowseDirection
+            // (+1 for down, -1 for up) because the scroll view recycles ~7 template
+            // slots, making sibling position unreliable for lists longer than 7 cards.
+            if (DuelState.LastBrowsePosition >= 0)
+            {
+                try
+                {
+                    // Confirm this is a browse list button (template(Clone) ancestor)
+                    if (!IsBrowseListButton(button))
+                    {
+                        // Not in a browse list — skip fallback for unrelated buttons
+                    }
+                    else
+                    {
+                        int player = DuelState.LastBrowsePlayer;
+                        int position = DuelState.LastBrowsePosition;
+                        int totalCards = 0;
+                        try { totalCards = Engine.GetCardNum(player, position); }
+                        catch { }
+
+                        // Apply direction to get the new logical index
+                        int dir = DuelState.BrowseDirection;
+                        int logicalIdx = DuelState.BrowseIndex + dir;
+
+                        // Clamp to valid range
+                        if (logicalIdx < 0) logicalIdx = 0;
+                        if (totalCards > 0 && logicalIdx >= totalCards)
+                            logicalIdx = totalCards - 1;
+
+                        DuelState.BrowseIndex = logicalIdx;
+
+                        // Suppress duplicate reads at list boundaries
+                        if (logicalIdx == DuelState.LastBrowseLogicalIdx)
+                            return "";
+                        DuelState.LastBrowseLogicalIdx = logicalIdx;
+
+                        string indexStr = totalCards > 0 ? $"{logicalIdx + 1} of {totalCards}" : null;
+
+                        // Don't reveal opponent's face-down cards
+                        if (!DuelState.IsMyPlayer(player))
+                        {
+                            try
+                            {
+                                if (!Engine.GetCardFace(player, position, logicalIdx))
+                                {
+                                    string msg = indexStr != null ? $"Face-down card, {indexStr}" : "Face-down card";
+                                    Speech.SayItem(msg);
+                                    return "";
+                                }
+                            }
+                            catch { }
+                        }
+
+                        int mrk = Engine.GetCardID(player, position, logicalIdx);
+                        if (mrk > 0)
+                        {
+                            CardReader.SpeakCardFromData(mrk, indexStr);
+                            return "";
+                        }
+                        else
+                        {
+                            string msg = indexStr != null ? $"Face-down card, {indexStr}" : "Face-down card";
+                            Speech.SayItem(msg);
+                            return "";
+                        }
+                    }
+                }
+                catch (Exception ex) { Log.Write($"[DuelHandler] Zone browse fallback: {ex.Message}"); }
+            }
 
             string name = button.name;
 
@@ -146,6 +221,90 @@ namespace BlindDuel
             }
             catch (Exception ex) { Log.Write($"[DuelHandler] SelectionIndex: {ex.Message}"); }
             return null;
+        }
+
+        /// <summary>
+        /// Check if button is inside a browse list (template(Clone) under Content,
+        /// or DuelListCard wrapper).
+        /// </summary>
+        private static bool IsBrowseListButton(SelectionButton button)
+        {
+            try
+            {
+                var current = button.transform;
+                for (int i = 0; i < 6 && current != null; i++)
+                {
+                    if (current.name.Contains("DuelListCard"))
+                        return true;
+                    if (current.name == "template(Clone)"
+                        && current.parent != null
+                        && current.parent.name == "Content")
+                        return true;
+                    current = current.parent;
+                }
+            }
+            catch { }
+            return false;
+        }
+
+        /// <summary>
+        /// Find a card's "X of Y" index string by scanning the Engine zone
+        /// for a matching card ID.
+        /// </summary>
+        private static string FindCardIndex(int player, int position, int totalCards, int cardid)
+        {
+            try
+            {
+                for (int i = 0; i < totalCards; i++)
+                {
+                    if (Engine.GetCardID(player, position, i) == cardid)
+                        return $"{i + 1} of {totalCards}";
+                }
+            }
+            catch { }
+            return null;
+        }
+
+        /// <summary>
+        /// Get 0-based index and total count of a button in a duel card list.
+        /// Walks up the hierarchy looking for either:
+        ///   - "DuelListCard" ancestor (selection lists)
+        ///   - "template(Clone)" ancestor whose parent is "Content" (browse view)
+        /// Returns (-1, 0) if no matching ancestor is found — this prevents
+        /// the zone browse fallback from firing on unrelated buttons.
+        /// </summary>
+        private static (int index, int total) GetDuelListCardIndex(SelectionButton button)
+        {
+            try
+            {
+                var current = button.transform;
+                for (int i = 0; i < 6 && current != null; i++)
+                {
+                    bool match = current.name.Contains("DuelListCard")
+                              || (current.name == "template(Clone)"
+                                  && current.parent != null
+                                  && current.parent.name == "Content");
+
+                    if (match)
+                    {
+                        var container = current.parent;
+                        if (container == null) break;
+
+                        int idx = -1, total = 0;
+                        for (int j = 0; j < container.childCount; j++)
+                        {
+                            var child = container.GetChild(j);
+                            if (!child.gameObject.activeInHierarchy) continue;
+                            if (child == current) idx = total;
+                            total++;
+                        }
+                        return (idx, total);
+                    }
+                    current = current.parent;
+                }
+            }
+            catch (Exception ex) { Log.Write($"[DuelHandler] ListCardIndex: {ex.Message}"); }
+            return (-1, 0);
         }
     }
 }

--- a/Handlers/DuelHandler.cs
+++ b/Handlers/DuelHandler.cs
@@ -75,6 +75,9 @@ namespace BlindDuel
                                 }
                                 catch { }
 
+                                // CardSelectionList = efeito solicitando seleção (Enter/A).
+                                // Nesses casos (invocar do extra deck, ativar efeito do cemitério,
+                                // selecionar card por efeito) sempre lê o card completo.
                                 string index2 = GetSelectionIndex(button);
                                 bool queued2 = PatchCardSelectionListSetTitle.ConsumeQueuedFlag();
                                 CardReader.SpeakCardFromData(data.cardid, index2, queued: queued2);
@@ -134,6 +137,7 @@ namespace BlindDuel
                         DuelState.LastBrowseLogicalIdx = logicalIdx;
 
                         string indexStr = totalCards > 0 ? $"{logicalIdx + 1} of {totalCards}" : null;
+                        string zoneLabel = BuildPileZoneLabel(player, position, indexStr);
 
                         // Don't reveal opponent's face-down cards
                         if (!DuelState.IsMyPlayer(player))
@@ -142,7 +146,9 @@ namespace BlindDuel
                             {
                                 if (!Engine.GetCardFace(player, position, logicalIdx))
                                 {
-                                    string msg = indexStr != null ? $"Face-down card, {indexStr}" : "Face-down card";
+                                    string msg = zoneLabel != null ? $"Face-down card, {zoneLabel}" : "Face-down card";
+                                    DuelState.CardDetailLines = null;
+                                    DuelState.CardDetailIndex = 0;
                                     Speech.SayItem(msg);
                                     return "";
                                 }
@@ -153,12 +159,14 @@ namespace BlindDuel
                         int mrk = Engine.GetCardID(player, position, logicalIdx);
                         if (mrk > 0)
                         {
-                            CardReader.SpeakCardFromData(mrk, indexStr);
+                            SpeakCardSummaryFromData(mrk, zoneLabel);
                             return "";
                         }
                         else
                         {
-                            string msg = indexStr != null ? $"Face-down card, {indexStr}" : "Face-down card";
+                            string msg = zoneLabel != null ? $"Face-down card, {zoneLabel}" : "Face-down card";
+                            DuelState.CardDetailLines = null;
+                            DuelState.CardDetailIndex = 0;
                             Speech.SayItem(msg);
                             return "";
                         }
@@ -181,6 +189,50 @@ namespace BlindDuel
             // Hand cards are handled by PatchHandCardSelect (SelectByViewIndex patch).
             // Action buttons (Summon, Set, etc.) — default behavior.
             return null;
+        }
+
+        private static void SpeakCardSummaryFromData(int mrk, string zoneLabel, bool queued = false)
+        {
+            BlindDuelCore.Preview.Clear();
+            var card = CardReader.ReadCardFromData(mrk);
+
+            var lines = card.GetDetailLines(out string summary, zone: zoneLabel);
+            DuelState.CardDetailLines = lines;
+            DuelState.CardDetailIndex = 0;
+
+            if (string.IsNullOrWhiteSpace(summary))
+                summary = !string.IsNullOrWhiteSpace(zoneLabel) ? zoneLabel : card.Name;
+
+            if (string.IsNullOrWhiteSpace(summary)) return;
+
+            if (queued)
+                Speech.SayQueued(summary);
+            else
+                Speech.SayItem(summary);
+        }
+
+        private static bool IsPileBrowsePosition(int position)
+        {
+            return position == Engine.PosGrave
+                || position == Engine.PosExclude
+                || position == Engine.PosExtra;
+        }
+
+        private static string BuildPileZoneLabel(int player, int position, string index)
+        {
+            string side = DuelState.IsMyPlayer(player) ? "" : "Opponent's ";
+            string zone = null;
+            if (position == Engine.PosGrave)
+                zone = $"{side}Graveyard";
+            else if (position == Engine.PosExclude)
+                zone = $"{side}Banished";
+            else if (position == Engine.PosExtra)
+                zone = $"{side}Extra Deck";
+
+            if (string.IsNullOrEmpty(zone))
+                return index;
+
+            return !string.IsNullOrEmpty(index) ? $"{zone}, {index}" : zone;
         }
 
         /// <summary>

--- a/Models/DuelState.cs
+++ b/Models/DuelState.cs
@@ -110,6 +110,32 @@ namespace BlindDuel
         /// </summary>
         public static (int player, int position, int viewIndex)? DeferredFieldFocus { get; set; }
 
+        /// <summary>
+        /// Player and position of the last focused pile zone (Graveyard, Extra Deck, Banished).
+        /// Used by DuelHandler to look up card IDs when browsing zone lists via X button.
+        /// </summary>
+        public static int LastBrowsePlayer { get; set; } = -1;
+        public static int LastBrowsePosition { get; set; } = -1;
+
+        /// <summary>
+        /// Logical scroll index for zone browse lists (Graveyard, Extra Deck, Banished).
+        /// Adjusted by BrowseDirection on each button focus event in the browse view.
+        /// Reset to -1 when a pile zone is focused (first focus will advance to 0).
+        /// </summary>
+        public static int BrowseIndex { get; set; } = -1;
+
+        /// <summary>
+        /// Direction of browse navigation: +1 = scrolling down, -1 = scrolling up.
+        /// Set by InputPatches when UP/DOWN input is detected during duel browse.
+        /// </summary>
+        public static int BrowseDirection { get; set; } = 1;
+
+        /// <summary>
+        /// Last logical index that was spoken in browse mode.
+        /// Used to suppress duplicate reads when clamped at list boundaries.
+        /// </summary>
+        public static int LastBrowseLogicalIdx { get; set; } = -1;
+
         public static void Clear()
         {
             Cards.Clear();
@@ -127,6 +153,11 @@ namespace BlindDuel
             LastQueuedButtonText = null;
             DeferredSelectionButton = null;
             DeferredFieldFocus = null;
+            LastBrowsePlayer = -1;
+            LastBrowsePosition = -1;
+            BrowseIndex = -1;
+            BrowseDirection = 1;
+            LastBrowseLogicalIdx = -1;
         }
 
         public static CardRoot FindCardAtPosition(UnityEngine.Vector3 position)

--- a/Patches/BrowseDirectionPatches.cs
+++ b/Patches/BrowseDirectionPatches.cs
@@ -1,0 +1,61 @@
+using HarmonyLib;
+using Il2CppYgomSystem;
+using UnityEngine;
+
+namespace BlindDuel
+{
+    [HarmonyPatch(typeof(GamePad_PC), nameof(GamePad_PC.GetKeyDown))]
+    class PatchBrowseDirectionGetKeyDown
+    {
+        static void Postfix(int Type, ref bool __result)
+        {
+            BrowseDirectionTracker.TrackKeyDown(Type, __result);
+        }
+    }
+
+    [HarmonyPatch(typeof(GamePad_PC), nameof(GamePad_PC.GetKey))]
+    class PatchBrowseDirectionGetKey
+    {
+        static void Postfix(int Type, ref bool __result)
+        {
+            BrowseDirectionTracker.TrackKey(Type, __result);
+        }
+    }
+
+    static class BrowseDirectionTracker
+    {
+        public static void TrackKeyDown(int type, bool result)
+        {
+            if (DuelState.LastBrowsePosition < 0) return;
+            if (!Application.isFocused) return;
+
+            if (type == GamePad.BUTTON_DOWN && (result || Input.GetKeyDown(KeyCode.DownArrow)))
+            {
+                DuelState.BrowseDirection = 1;
+                return;
+            }
+
+            if (type == GamePad.BUTTON_UP && (result || Input.GetKeyDown(KeyCode.UpArrow)))
+            {
+                DuelState.BrowseDirection = -1;
+            }
+        }
+
+        public static void TrackKey(int type, bool result)
+        {
+            if (DuelState.LastBrowsePosition < 0) return;
+            if (!Application.isFocused) return;
+
+            if (type == GamePad.BUTTON_DOWN && (result || Input.GetKey(KeyCode.DownArrow)))
+            {
+                DuelState.BrowseDirection = 1;
+                return;
+            }
+
+            if (type == GamePad.BUTTON_UP && (result || Input.GetKey(KeyCode.UpArrow)))
+            {
+                DuelState.BrowseDirection = -1;
+            }
+        }
+    }
+}

--- a/Patches/DuelPatches.cs
+++ b/Patches/DuelPatches.cs
@@ -273,6 +273,27 @@ namespace BlindDuel
 
                 string zone = GetZoneName(player, position, viewIndex);
 
+                // Track pile zone focus so DuelHandler can look up card IDs
+                // when the player opens the zone's card list (X button).
+                if (position == Engine.PosGrave || position == Engine.PosExtra || position == Engine.PosExclude)
+                {
+                    DuelState.LastBrowsePlayer = player;
+                    DuelState.LastBrowsePosition = position;
+                    DuelState.BrowseIndex = -1;
+                    DuelState.BrowseDirection = 1;
+                    DuelState.LastBrowseLogicalIdx = -1;
+                }
+                else
+                {
+                    // Left the pile zone — clear browse state so the fallback
+                    // doesn't fire on unrelated buttons.
+                    DuelState.LastBrowsePlayer = -1;
+                    DuelState.LastBrowsePosition = -1;
+                    DuelState.BrowseIndex = -1;
+                    DuelState.BrowseDirection = 1;
+                    DuelState.LastBrowseLogicalIdx = -1;
+                }
+
                 // Pile zones (Extra Deck, Deck) — just speak the zone name,
                 // don't read individual cards from the pile.
                 if (position == Engine.PosExtra || position == Engine.PosDeck)


### PR DESCRIPTION
This PR adds bidirectional zone browsing in duel lists while staying compatible with upstream `InputPatches` updates.

## Changes
- `Handlers/DuelHandler.cs`
- `Models/DuelState.cs`
- `Patches/DuelPatches.cs`
- `Patches/BrowseDirectionPatches.cs` (new)

## Notes
- No changes to `Patches/InputPatches.cs` in this clean branch.
- Branch is based on current upstream `master`.
- Local build passed (`0` errors).

## Behavior
- Zone browse now supports both directions consistently (down and up) in duel pile lists (e.g., Extra Deck).