### PR TITLE
Deck editor: virtual toolbar + accessible filter dialog

### DIFF
--- a/Core/BlindDuelCore.cs
+++ b/Core/BlindDuelCore.cs
@@ -121,6 +121,8 @@ namespace BlindDuel
                 catch { Speech.SayImmediate("Points unavailable"); }
             }
 
+            VirtualToolbar.Update();
+
             // Duel log selection tracking
             if (DuelState.IsDuelLogOpen)
                 DuelLogReader.PollSelection();

--- a/Handlers/DeckHandler.cs
+++ b/Handlers/DeckHandler.cs
@@ -13,6 +13,7 @@ namespace BlindDuel
         // Section tracking — detect when user moves between deck/collection/main/extra
         private DeckEditViewController2.ViewType _lastViewType = DeckEditViewController2.ViewType.None;
         private DeckCard.LocationInDeck _lastDeckLocation = DeckCard.LocationInDeck.NA;
+        private string _lastFilterGroupName;
 
         public bool CanHandle(string viewControllerName) =>
             viewControllerName is "DeckSelect" or "DeckEdit" or "DeckBrowser";
@@ -21,6 +22,12 @@ namespace BlindDuel
         {
             _lastViewType = DeckEditViewController2.ViewType.None;
             _lastDeckLocation = DeckCard.LocationInDeck.NA;
+            _lastFilterGroupName = null;
+
+            if (viewControllerName is "DeckEdit" or "DeckSelect")
+                VirtualToolbar.EnableFor(this);
+            else
+                VirtualToolbar.Disable();
 
             if (viewControllerName == "DeckEdit")
                 return AnnounceDeckEdit();
@@ -33,6 +40,16 @@ namespace BlindDuel
 
         public string OnButtonFocused(SelectionButton button)
         {
+            // FilterDialog toggle — prepend the group name so users know which of
+            // ~11 filter categories (Rarity, Frame, Type, ATK, ...) they're in.
+            try
+            {
+                var filterGroup = button.GetComponentInParent<FilterDialog.FilterGroup>();
+                if (filterGroup != null)
+                    return HandleFilterToggle(button, filterGroup);
+            }
+            catch (Exception ex) { Log.Write($"[DeckHandler] FilterGroup: {ex.Message}"); }
+
             // DeckBox widget (deck list items on DeckSelect)
             try
             {
@@ -128,6 +145,76 @@ namespace BlindDuel
         }
 
         // --- Button handlers ---
+
+        private string HandleFilterToggle(SelectionButton button, FilterDialog.FilterGroup group)
+        {
+            string groupName = group.m_GroupNameText?.text?.Trim();
+
+            // Dedupe — only announce the group name when moving between categories,
+            // so navigating 25 type filters doesn't repeat "Type" every step.
+            string announceGroup = groupName == _lastFilterGroupName ? null : groupName;
+            _lastFilterGroupName = groupName;
+
+            // Range filter (ATK/DEF) — min/max input fields, not toggles.
+            var slider = button.GetComponentInParent<FilterSlider>();
+            if (slider != null)
+                return BuildSliderText(button, slider, announceGroup);
+
+            string buttonText = TextExtractor.ExtractFirst(button.gameObject);
+
+            // Link arrow filters use labels "Link_1".."Link_8" — N is the 1-based bit
+            // index into Content.LinkMarkerBit (1=UpLeft, 2=Up, ..., 8=DownRight).
+            if (string.IsNullOrEmpty(buttonText))
+            {
+                var linkMark = button.GetComponentInParent<FilterLinkMark>();
+                string label = linkMark?.m_Label;
+                if (label != null && label.StartsWith("Link_")
+                    && int.TryParse(label.Substring(5), out int n)
+                    && n >= 1 && n <= 8)
+                    buttonText = FormatLinkArrows(1 << (n - 1));
+            }
+
+            if (string.IsNullOrEmpty(buttonText)) return null;
+
+            string result = !string.IsNullOrEmpty(announceGroup)
+                ? $"{announceGroup}, {buttonText}"
+                : buttonText;
+
+            var (index, total) = TransformSearch.GetButtonIndex(button);
+            if (total > 1)
+                result += $"\n{index} of {total}";
+
+            return result;
+        }
+
+        private static string BuildSliderText(SelectionButton button, FilterSlider slider, string groupName)
+        {
+            string side;
+            string value;
+
+            if (button == slider.m_ButtonMin)
+            {
+                side = "Min";
+                value = slider.m_InputFieldWidgetMin?.m_TMPInputFieldCache?.text;
+            }
+            else if (button == slider.m_ButtonMax)
+            {
+                side = "Max";
+                value = slider.m_InputFieldWidgetMax?.m_TMPInputFieldCache?.text;
+            }
+            else
+            {
+                return null;
+            }
+
+            // Strip zero-width spaces and whitespace — the placeholder text when empty.
+            value = value?.Replace("​", "").Trim();
+
+            string result = !string.IsNullOrEmpty(groupName) ? $"{groupName}, {side}" : side;
+            if (!string.IsNullOrEmpty(value))
+                result += $", {value}";
+            return result;
+        }
 
         private string HandleDeckBox(DeckBox deckBox)
         {

--- a/Patches/ButtonPatches.cs
+++ b/Patches/ButtonPatches.cs
@@ -14,7 +14,7 @@ namespace BlindDuel
     class PatchColorContainerGraphic
     {
         // parent.parent name → label
-        private static readonly Dictionary<string, string> ParentLabels = new()
+        internal static readonly Dictionary<string, string> ParentLabels = new()
         {
             { "ButtonMaintenance", "Maintenance" },
             { "ButtonBug", "Issues" },

--- a/Patches/InputPatches.cs
+++ b/Patches/InputPatches.cs
@@ -22,6 +22,8 @@ namespace BlindDuel
             // Suppress right stick up/down from game during duels (SDL3 reads it directly)
             if (__result && InputMap.IsRightStickDuelSuppress(Type)) { __result = false; return; }
 
+            if (VirtualToolbar.IsActive) { __result = false; return; }
+
             if (__result) return;
             if (!Application.isFocused) return;
 
@@ -53,6 +55,8 @@ namespace BlindDuel
         static void Postfix(int Type, ref bool __result)
         {
             if (__result && InputMap.IsRightStickDuelSuppress(Type)) { __result = false; return; }
+
+            if (VirtualToolbar.IsActive) { __result = false; return; }
 
             if (__result) return;
             if (!Application.isFocused) return;

--- a/UI/VirtualToolbar.cs
+++ b/UI/VirtualToolbar.cs
@@ -1,0 +1,295 @@
+using System;
+using System.Collections.Generic;
+using HarmonyLib;
+using Il2CppYgomGame.Menu;
+using Il2CppYgomSystem.UI;
+using UnityEngine;
+
+namespace BlindDuel
+{
+    /// <summary>
+    /// Exposes shortcut-only buttons (Sort, Filter, Clear, NotOwn, Search, Save,
+    /// Menu, etc.) as an arrow-navigable virtual list. L1 (keyboard I) toggles;
+    /// Left/Right cycles; Enter activates; Up/Down/Backspace/Escape exit.
+    /// Handlers opt in via EnableFor; the L1 hijack lives in InputPatches.
+    /// </summary>
+    public static class VirtualToolbar
+    {
+        private static IMenuHandler _owner;
+        private static bool _active;
+        private static readonly List<Entry> _entries = new();
+        private static int _index;
+
+        // Dialogs that have their own toolbar-style action strip (OK/Cancel/Help, etc.)
+        // and should keep the virtual toolbar available while they're open.
+        private static readonly HashSet<string> ToolbarFriendlyDialogs = new() { "FilterDialogUI" };
+
+        public static bool IsActive => _active;
+
+        public static void EnableFor(IMenuHandler handler) => _owner = handler;
+
+        public static void Disable()
+        {
+            _owner = null;
+            if (_active) Exit(silent: true);
+        }
+
+        /// <summary>Closes the toolbar if active. Used by the OnBack/SaveDialog patches.</summary>
+        public static bool OnBackPressed()
+        {
+            if (!_active) return false;
+            Exit(silent: false);
+            return true;
+        }
+
+        /// <summary>True when an owner handler is active and (no dialog OR a toolbar-friendly dialog).</summary>
+        public static bool CanToggle()
+        {
+            if (_owner == null || HandlerRegistry.Current != _owner) return false;
+            string dialog = NavigationState.LastDialogTitle;
+            if (!string.IsNullOrEmpty(dialog) && !ToolbarFriendlyDialogs.Contains(dialog)) return false;
+            return true;
+        }
+
+        public static void RequestOpen()  { if (!_active) Enter(); }
+        public static void RequestClose() { if (_active) Exit(silent: false); }
+
+        public static void Update()
+        {
+            if (_owner == null || HandlerRegistry.Current != _owner)
+            {
+                if (_active) Exit(silent: true);
+                return;
+            }
+
+            // Most dialogs close the toolbar. Whitelisted ones (FilterDialog) keep it
+            // available so the dialog's own action buttons can be navigated too.
+            string dialog = NavigationState.LastDialogTitle;
+            if (!string.IsNullOrEmpty(dialog) && !ToolbarFriendlyDialogs.Contains(dialog))
+            {
+                if (_active) Exit(silent: true);
+                return;
+            }
+
+            // L1 toggles: keyboard I, or XInput L1 (joystick button 4).
+            bool togglePressed = Input.GetKeyDown(KeyCode.I)
+                              || Input.GetKeyDown(KeyCode.JoystickButton4);
+
+            if (!_active)
+            {
+                if (togglePressed) Enter();
+                return;
+            }
+
+            if (togglePressed) { Exit(silent: false); return; }
+
+            if (Input.GetKeyDown(KeyCode.LeftArrow))            MovePrev();
+            else if (Input.GetKeyDown(KeyCode.RightArrow))      MoveNext();
+            else if (Input.GetKeyDown(KeyCode.Return))          Activate();
+            // Backspace/Escape are handled by the OnBack/SaveDialog patches.
+            else if (Input.GetKeyDown(KeyCode.UpArrow)
+                  || Input.GetKeyDown(KeyCode.DownArrow))       Exit(silent: false);
+        }
+
+        private static void Enter()
+        {
+            BuildEntries();
+            if (_entries.Count == 0)
+            {
+                Speech.SayImmediate("No toolbar shortcuts here");
+                return;
+            }
+            _active = true;
+            _index = 0;
+            AnnounceCurrent("Toolbar. ");
+        }
+
+        private static void Exit(bool silent)
+        {
+            if (!_active) return;
+            _active = false;
+            _entries.Clear();
+            if (!silent) Speech.SayImmediate("Toolbar closed");
+        }
+
+        private static void MoveNext()
+        {
+            if (_entries.Count == 0) return;
+            _index = (_index + 1) % _entries.Count;
+            AnnounceCurrent();
+        }
+
+        private static void MovePrev()
+        {
+            if (_entries.Count == 0) return;
+            _index = (_index - 1 + _entries.Count) % _entries.Count;
+            AnnounceCurrent();
+        }
+
+        private static void Activate()
+        {
+            if (_entries.Count == 0) return;
+            var entry = _entries[_index];
+            if (entry.Button == null)
+            {
+                Speech.SayImmediate("Button unavailable");
+                return;
+            }
+            try
+            {
+                entry.Button.OnClick();
+                bool? state = GetToggleState(entry.Button);
+                if (state.HasValue)
+                    Speech.SayImmediate($"{entry.Label}, {(state.Value ? "on" : "off")}");
+                else
+                    Speech.SayImmediate($"{entry.Label} activated");
+                Exit(silent: true);
+            }
+            catch (Exception ex)
+            {
+                Log.Write($"[VirtualToolbar] OnClick failed for {entry.Label}: {ex.Message}");
+                Speech.SayImmediate("Activation failed");
+            }
+        }
+
+        private static void AnnounceCurrent(string prefix = "")
+        {
+            var entry = _entries[_index];
+            string indexText = _entries.Count > 1 ? $", {_index + 1} of {_entries.Count}" : "";
+            string stateText = "";
+            bool? state = GetToggleState(entry.Button);
+            if (state.HasValue) stateText = state.Value ? ", on" : ", off";
+            Speech.SayImmediate($"{prefix}{entry.Label}{stateText}{indexText}");
+        }
+
+        private static bool? GetToggleState(SelectionButton button)
+        {
+            if (button == null) return null;
+            try
+            {
+                var imageOn = button.transform.Find("ImageOn");
+                var imageOff = button.transform.Find("ImageOff");
+                if (imageOn == null || imageOff == null) return null;
+                bool isOn = imageOn.gameObject.activeInHierarchy;
+
+                // NotOwnButton's game-side meaning is "Show All Cards" — its ImageOn
+                // means the filter is OFF. Invert so our label matches user intuition.
+                if (button.gameObject.name == "NotOwnButton")
+                    isOn = !isOn;
+
+                return isOn;
+            }
+            catch { return null; }
+        }
+
+        private static void BuildEntries()
+        {
+            _entries.Clear();
+
+            // Scope to the active dialog when one is open — otherwise the scene scan
+            // would also pick up the underlying screen's icons that aren't reachable.
+            Il2CppInterop.Runtime.InteropTypes.Arrays.Il2CppArrayBase<ShortcutIcon> icons;
+            var dialogRoot = FindActiveDialogRoot();
+            if (dialogRoot != null)
+                icons = dialogRoot.GetComponentsInChildren<ShortcutIcon>(false);
+            else
+                icons = UnityEngine.Object.FindObjectsOfType<ShortcutIcon>();
+            if (icons == null) return;
+
+            var seen = new HashSet<int>();
+            for (int i = 0; i < icons.Count; i++)
+            {
+                var icon = icons[i];
+                if (icon == null || !icon.gameObject.activeInHierarchy) continue;
+                if (icon.keyType == SelectorManager.KeyType.None) continue;
+
+                var btn = FindButtonAncestor(icon.transform);
+                if (btn == null) continue;
+
+                int id = btn.gameObject.GetInstanceID();
+                if (!seen.Add(id)) continue; // dedupe — modifier icon points at same button
+
+                string label = ResolveLabel(btn.gameObject.name);
+                if (string.IsNullOrEmpty(label)) continue;
+
+                _entries.Add(new Entry { Label = label, Button = btn });
+            }
+        }
+
+        private static GameObject FindActiveDialogRoot()
+        {
+            if (string.IsNullOrEmpty(NavigationState.LastDialogTitle)) return null;
+            var dialogManager = GameObject.Find("UI/OverlayCanvas/DialogManager");
+            if (dialogManager == null) return null;
+            for (int i = 0; i < dialogManager.transform.childCount; i++)
+            {
+                var dialogRoot = dialogManager.transform.GetChild(i);
+                if (!dialogRoot.gameObject.activeInHierarchy) continue;
+                for (int j = 0; j < dialogRoot.childCount; j++)
+                {
+                    var dialogUI = dialogRoot.GetChild(j);
+                    if (!dialogUI.gameObject.activeInHierarchy) continue;
+                    if (!dialogUI.name.Contains("(Clone)")) continue;
+                    return dialogUI.gameObject;
+                }
+            }
+            return null;
+        }
+
+        private static SelectionButton FindButtonAncestor(Transform t)
+        {
+            int depth = 0;
+            while (t != null && depth < 5)
+            {
+                var btn = t.GetComponent<SelectionButton>();
+                if (btn != null) return btn;
+                t = t.parent;
+                depth++;
+            }
+            return null;
+        }
+
+        private static string ResolveLabel(string buttonName)
+        {
+            // Labels for buttons that only exist in the virtual toolbar's view —
+            // not reachable via normal focus, so they aren't in ButtonPatches.ParentLabels.
+            switch (buttonName)
+            {
+                case "InputButton": return "Search";
+                case "NotOwnButton": return "Hide unowned cards filter";
+            }
+
+            if (PatchColorContainerGraphic.ParentLabels.TryGetValue(buttonName, out var label))
+                return label;
+            if (string.IsNullOrEmpty(buttonName)) return null;
+            if (buttonName.StartsWith("Button")) return buttonName.Substring(6);
+            if (buttonName.EndsWith("Button")) return buttonName.Substring(0, buttonName.Length - 6);
+            return buttonName;
+        }
+
+        private struct Entry
+        {
+            public string Label;
+            public SelectionButton Button;
+        }
+    }
+
+    [HarmonyPatch(typeof(ViewControllerManager), nameof(ViewControllerManager.OnBack))]
+    class PatchOnBackForToolbar
+    {
+        [HarmonyPrefix]
+        static bool Prefix(ref bool __result)
+        {
+            if (VirtualToolbar.OnBackPressed()) { __result = true; return false; }
+            return true;
+        }
+    }
+
+    // Catches the "back with unsaved changes" path that bypasses OnBack.
+    [HarmonyPatch(typeof(SaveDialogViewController), nameof(SaveDialogViewController.Open))]
+    class PatchSaveDialogOpenForToolbar
+    {
+        [HarmonyPrefix]
+        static bool Prefix() => !VirtualToolbar.OnBackPressed();
+    }
+}


### PR DESCRIPTION
## Summary

The deck editor has ~10 action buttons (Sort, Filter, Clear, Hide unowned, Search, Save, Menu, Switch display, Regulation, plus tabs) that are gamepad-shortcut-only — they aren't in the arrow-key focus path, and a blind player can't discover the bindings from the visual icon hints. Same applies to the deck-list screen's `ButtonStructureInfo`, `OpenDeckSearch`, etc., and the Filter dialog's OK/Cancel/Help row.

This PR adds a **virtual toolbar**: press **L1** (keyboard `I` or XInput button 4) to open an arrow-navigable list of those shortcut-only buttons, Enter to activate, L1 again or Up/Down/Backspace/Escape to close. Also reworks the Filter dialog so every group (toggles, ATK/DEF ranges, Link arrows) reads with full context.

## Code changes

### New: `UI/VirtualToolbar.cs`

A handler-scoped virtual list. `EnableFor(handler)` opts in; the toolbar self-disables when a different handler becomes current. Discovery is a `ShortcutIcon` scene scan, deduped by owning `SelectionButton`, labeled via `ButtonPatches.ParentLabels` with two special cases (`InputButton` → \"Search\", `NotOwnButton` → \"Hide unowned cards filter\").

- Toggle state is read off `ImageOn`/`ImageOff` sibling GameObjects and announced (\"on\" / \"off\"). `NotOwnButton` is inverted because game-side it's the \"Show All Cards\" toggle.
- Activation calls `SelectionButton.OnClick()` and always closes the toolbar (state-aware announcement first for toggles).
- Two Harmony prefixes also live in this file:
  - `ViewControllerManager.OnBack` — Backspace/Escape consumed by toolbar instead of exiting the screen.
  - `SaveDialogViewController.Open` — modified-deck-exit path bypasses OnBack; this catches it.
- Allows the toolbar on whitelisted dialogs (currently `FilterDialogUI`) with the scan scoped to the dialog's GameObject so the underlying screen's toolbar doesn't leak in.

### Modified: `Handlers/DeckHandler.cs`

- Opts the toolbar in on `\"DeckEdit\"` and `\"DeckSelect\"` via `VirtualToolbar.EnableFor(this)`.
- `HandleFilterToggle` covers the Filter dialog's groups: prepends the localized group name with **dedupe** (group only announced on first item in a category, not every step), routes ATK/DEF buttons through a slider-aware `BuildSliderText` helper (reads min/max from `m_TMPInputFieldCache.text`), and routes the link-arrow buttons (`FilterLinkMark` widgets with `Link_1..Link_8` labels) through the existing `FormatLinkArrows` for consistent wording with card readouts.

### Modified: `Patches/ButtonPatches.cs`

`ParentLabels` widened from `private` → `internal` so `VirtualToolbar` reuses the same label map for non-arrow-reachable buttons. No new dictionary entries.

### Modified: `Patches/InputPatches.cs`

Both `GamePad_PC.GetKeyDown` and `GetKey` postfixes short-circuit to `__result = false` when `VirtualToolbar.IsActive`, so keyboard/gamepad input doesn't leak into the game while the user is navigating the virtual list.

### Modified: `Core/BlindDuelCore.cs`

One-line `VirtualToolbar.Update()` added to the polling loop.

## Test plan

- **Deck list (DeckSelect)**: press `I` → 5–6 shortcut buttons listed (Structure Info, Open Deck Search, etc.). Activate, confirm correct behavior.
- **Deck editor (DeckEdit)**: press `I` → 10 buttons (Clear/Sort/Filter/NotOwn/Search/Bookmark/Menu/Save/Switch display/Regulation). Toggles (Filter, NotOwn) read state, activation flips and closes. Regular buttons activate and close.
- **Filter dialog**: arrow through Rarity → Card Frame → Attribute → Spell/Trap → Type → Level/Rank → Link → Link Marker → Pendulum Scale → ATK (min+max) → DEF → Abilities → Finish → Limit. Category prefix dedupes within a group, ATK/DEF read entered numeric values, link arrows announce as \"up left\" etc.
- **Filter dialog toolbar**: while the filter dialog is open, press `I` → toolbar opens with only the dialog's own action buttons (scoped scan). Activate OK → filter applies, toolbar closes.
- **Backspace handling**: with toolbar open, Backspace closes only the toolbar. Second Backspace exits the screen normally (or opens SaveDialog on a modified deck — but only after the toolbar closes).
- **Other screens** (Home, Settings, in-duel): pressing `I` does nothing. `L1` passes through to the game normally for combo modifiers etc.

## Risks / notes

- **`SaveDialogViewController.Open` prefix is global.** Today only DeckHandler opts into the toolbar, so the suppression only fires there, but any future handler that calls `EnableFor(this)` will also suppress save-confirmation dialogs while the toolbar is open. Intentional for the consistent \"back closes toolbar first\" UX — flagging for review.
- **Combos break in deck editor for L1.** Holding `I` + pressing `F` no longer triggers Clear via combo, because `I` now toggles the toolbar. Acceptable trade — the toolbar exposes Clear as a named entry. R1-side combos (Switch display / Regulation) still work since R1 isn't repurposed.
- **`Link_N` label format** is empirically derived from the live game; falls back gracefully (no announcement) if a future patch renames them.
- **Dialog whitelist** is just `FilterDialogUI` for now. Adding another dialog to the toolbar = add its `LastDialogTitle` value to the `ToolbarFriendlyDialogs` set.
- **One-frame L1 leak when opening.** Pressing L1 in the deck editor may fire one frame of \"L1 pressed\" through the gamepad pipeline before the toolbar's `IsActive` suppression engages. Harmless in practice (L1 alone has no game-side effect), but worth noting.