### PR TITLE
Duel Room flow accessibility + InputDigit dialog reader

### DIFF
--- a/Core/BlindDuelCore.cs
+++ b/Core/BlindDuelCore.cs
@@ -141,8 +141,20 @@ namespace BlindDuel
             DialogDetector.Poll();
             ScreenDetector.Poll();
 
+            // Speak the current value of any open InputDigit (+/-) dialog as it changes.
+            InputDigitWatcher.Poll();
+
             // Settings slider / toggle value-change announcement
             SettingsHandler.PollSettingValue();
+
+            // Re-announce friend-selection count when it changes on the RoomInvite screen.
+            RoomInviteHandler.Poll();
+
+            // Re-announce member / spectator counts + seat occupancy in the Duel Room.
+            RoomHandler.Poll();
+
+            // Re-announce ON/OFF toggle and other in-row setting flips on Create Room.
+            RoomCreateHandler.Poll();
         }
 
         /// <summary>
@@ -168,6 +180,7 @@ namespace BlindDuel
         {
             CardReader.ReadPreviewAndSpeak();
         }
+
 
         /// <summary>
         /// Invokable method for reading MDMarkup article content (notifications, news).

--- a/Core/Speech.cs
+++ b/Core/Speech.cs
@@ -158,6 +158,16 @@ namespace BlindDuel
         }
 
         /// <summary>
+        /// Reset the header dedup so the next AnnounceScreen speaks even if it
+        /// matches the last header. Called when a dialog closes — otherwise the
+        /// same dialog re-opening with identical text gets silently suppressed.
+        /// </summary>
+        public static void ResetHeaderDedup()
+        {
+            _lastHeader = "";
+        }
+
+        /// <summary>
         /// Silence current speech.
         /// </summary>
         public static void Silence()

--- a/Detection/DialogDetector.cs
+++ b/Detection/DialogDetector.cs
@@ -58,6 +58,7 @@ namespace BlindDuel
                             labeled.Add((r.Path, r.Text));
 
                         var (title, body) = ElementReader.ExtractTitleAndBody(labeled);
+                        if (body != null && ElementReader.LooksLikeButtonText(body)) body = null;
 
                         if (ElementReader.IsPlaceholder(title))
                         {
@@ -84,9 +85,14 @@ namespace BlindDuel
                     }
                 }
 
-                // Reset when no active dialog exists (dialog truly closed)
+                // Reset when no active dialog exists (dialog truly closed). Also clear
+                // the AnnounceScreen header dedup so an identical dialog re-opening
+                // doesn't get silently suppressed by the screen-level dedup check.
                 if (!foundActive)
+                {
                     NavigationState.LastDialogTitle = "";
+                    Speech.ResetHeaderDedup();
+                }
             }
             catch (Exception ex) { Log.Write($"[DialogDetector] {ex.Message}"); }
         }
@@ -179,6 +185,7 @@ namespace BlindDuel
                     labeled.Add((r.Path, r.Text));
 
                 var (title, body) = ElementReader.ExtractTitleAndBody(labeled);
+                if (body != null && ElementReader.LooksLikeButtonText(body)) body = null;
                 if (string.IsNullOrEmpty(title)) return;
 
                 // Mark as announced so Poll() won't re-announce

--- a/Detection/InputDigitWatcher.cs
+++ b/Detection/InputDigitWatcher.cs
@@ -1,0 +1,68 @@
+using System;
+using Il2CppYgomGame.Menu.Common;
+using Il2CppYgomSystem.UI;
+using UnityEngine;
+
+namespace BlindDuel
+{
+    // InputDigit dialogs live under UI/OverlayCanvas/DialogManager rather than the
+    // main ContentManager that ScreenDetector.GetFocusVC inspects, so HandlerRegistry
+    // doesn't route to them. We find the active instance via Resources lookup and
+    // poll _currentValue so +/- clicks become audible.
+    public static class InputDigitWatcher
+    {
+        private static int _lastValue = int.MinValue;
+
+        // The dialog's "-" button label reads as a sign that glues to the trailing
+        // sibling-index ("- 2 of 2" → "minus 2"). Substitute verbal labels for the
+        // four step buttons so the screen reader pronounces them unambiguously.
+        public static string GetButtonLabel(SelectionButton button) => button?.name switch
+        {
+            "LargeMinusButton" => "minus 10",
+            "MinusButton" => "minus 1",
+            "PlusButton" => "plus 1",
+            "LargePlusButton" => "plus 10",
+            _ => null,
+        };
+
+        public static void Poll()
+        {
+            try
+            {
+                var all = Resources.FindObjectsOfTypeAll<InputDigitViewController>();
+                InputDigitViewController vc = null;
+                if (all != null)
+                {
+                    for (int i = 0; i < all.Length; i++)
+                    {
+                        var candidate = all[i];
+                        if (candidate != null && candidate.gameObject.activeInHierarchy)
+                        {
+                            vc = candidate;
+                            break;
+                        }
+                    }
+                }
+
+                if (vc == null)
+                {
+                    _lastValue = int.MinValue;
+                    return;
+                }
+
+                int current = vc._currentValue;
+                if (_lastValue == int.MinValue)
+                {
+                    _lastValue = current;
+                    return;
+                }
+                if (current != _lastValue)
+                {
+                    _lastValue = current;
+                    Speech.SayImmediate(current.ToString());
+                }
+            }
+            catch { }
+        }
+    }
+}

--- a/Handlers/RoomCreateHandler.cs
+++ b/Handlers/RoomCreateHandler.cs
@@ -1,0 +1,142 @@
+using System;
+using Il2CppYgomGame.Room;
+using Il2CppYgomSystem.UI;
+using UnityEngine;
+
+namespace BlindDuel
+{
+    public class RoomCreateHandler : IMenuHandler
+    {
+        // ON/OFF toggles flip in place without firing a focus change, so we track the
+        // focused row's TextSetting value across frames to detect the flip.
+        private static SelectionButton _lastFocused;
+        private static string _lastSetting;
+
+        public bool CanHandle(string viewControllerName) => viewControllerName == "RoomCreate";
+
+        public bool OnScreenEntered(string viewControllerName)
+        {
+            _lastFocused = null;
+            _lastSetting = null;
+
+            string header = ScreenDetector.ReadGameHeaderText();
+            string announcement = !string.IsNullOrWhiteSpace(header) ? header : "Create a Room";
+            Speech.AnnounceScreen(announcement);
+            return true;
+        }
+
+        public static void Poll()
+        {
+            try
+            {
+                if (HandlerRegistry.Current is not RoomCreateHandler)
+                {
+                    _lastFocused = null;
+                    _lastSetting = null;
+                    return;
+                }
+
+                var btn = SelectorManager.currentItem?.TryCast<SelectionButton>();
+                if (btn == null || btn.WasCollected)
+                {
+                    _lastFocused = null;
+                    _lastSetting = null;
+                    return;
+                }
+
+                var vc = GetVC();
+                if (vc == null) return;
+                if (!TryGetRow(vc, btn, out var row)) return;
+
+                string current = ReadChild(row, "TextSetting");
+
+                if (btn != _lastFocused)
+                {
+                    _lastFocused = btn;
+                    _lastSetting = current;
+                    return;
+                }
+
+                if (!string.Equals(current, _lastSetting, StringComparison.Ordinal))
+                {
+                    _lastSetting = current;
+                    if (!string.IsNullOrWhiteSpace(current))
+                        Speech.SayImmediate(current);
+                }
+            }
+            catch { }
+        }
+
+        public string OnButtonFocused(SelectionButton button)
+        {
+            try
+            {
+                if (button.name == "ButtonOK")
+                {
+                    string txt = TextExtractor.ExtractFirst(button.gameObject);
+                    return !string.IsNullOrWhiteSpace(txt) ? txt : "Create Room";
+                }
+
+                var vc = GetVC();
+                if (vc == null) return null;
+
+                if (TryGetRow(vc, button, out var row))
+                    return FormatSettingRow(row);
+            }
+            catch (Exception ex) { Log.Write($"[RoomCreateHandler] Button error: {ex.Message}"); }
+            return null;
+        }
+
+        private static bool TryGetRow(RoomCreateViewController vc, SelectionButton button, out GameObject row)
+        {
+            row = null;
+            var isv = vc.isv;
+            if (isv == null) return false;
+
+            Transform t = button.transform;
+            for (int i = 0; i < 8 && t != null; i++)
+            {
+                try
+                {
+                    if (isv.GetDataIndexByEntity(t.gameObject) >= 0)
+                    {
+                        row = t.gameObject;
+                        return true;
+                    }
+                }
+                catch { }
+                t = t.parent;
+            }
+            return false;
+        }
+
+        private static string FormatSettingRow(GameObject row)
+        {
+            string title = ReadChild(row, "TextTitle");
+            string setting = ReadChild(row, "TextSetting");
+
+            if (string.IsNullOrWhiteSpace(title))
+                return null;
+            if (string.IsNullOrWhiteSpace(setting))
+                return title;
+            return $"{title}, {setting}";
+        }
+
+        private static string ReadChild(GameObject root, string childName)
+        {
+            try
+            {
+                var t = TransformSearch.FindByName(root.transform, childName);
+                if (t == null) return null;
+                return TextExtractor.ExtractFirst(t.gameObject);
+            }
+            catch { return null; }
+        }
+
+        private static RoomCreateViewController GetVC()
+        {
+            try { return ScreenDetector.GetFocusVC()?.TryCast<RoomCreateViewController>(); }
+            catch { return null; }
+        }
+    }
+}

--- a/Handlers/RoomEntryHandler.cs
+++ b/Handlers/RoomEntryHandler.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using Il2CppYgomGame.Room;
+using Il2CppYgomSystem.UI;
+using UnityEngine;
+
+namespace BlindDuel
+{
+    public class RoomEntryHandler : IMenuHandler
+    {
+        public bool CanHandle(string viewControllerName) => viewControllerName == "RoomEntry";
+
+        public bool OnScreenEntered(string viewControllerName)
+        {
+            string header = ScreenDetector.ReadGameHeaderText();
+            string announcement = !string.IsNullOrWhiteSpace(header) ? header : "Room List";
+
+            try
+            {
+                int count = GetVC()?.dataList?.Count ?? -1;
+                if (count == 0)
+                    announcement += ", no rooms available";
+                else if (count > 0)
+                    announcement += $", {count} rooms";
+            }
+            catch (Exception ex) { Log.Write($"[RoomEntryHandler] Screen error: {ex.Message}"); }
+
+            Speech.AnnounceScreen(announcement);
+            return true;
+        }
+
+        public string OnButtonFocused(SelectionButton button)
+        {
+            try
+            {
+                if (button.name == "ButtonReload") return "Reload room list";
+                if (button.name == "ButtonFilter") return "Filter rooms";
+
+                var vc = GetVC();
+                if (vc == null) return null;
+
+                if (TryGetDataIndex(vc, button, out int idx))
+                    return FormatRoom(vc, idx);
+            }
+            catch (Exception ex) { Log.Write($"[RoomEntryHandler] Button error: {ex.Message}"); }
+            return null;
+        }
+
+        private static bool TryGetDataIndex(RoomEntryViewController vc, SelectionButton button, out int idx)
+        {
+            idx = -1;
+            var isv = vc.isv;
+            if (isv == null) return false;
+
+            Transform t = button.transform;
+            for (int i = 0; i < 8 && t != null; i++)
+            {
+                try
+                {
+                    int candidate = isv.GetDataIndexByEntity(t.gameObject);
+                    if (candidate >= 0) { idx = candidate; return true; }
+                }
+                catch { }
+                t = t.parent;
+            }
+            return false;
+        }
+
+        private static string FormatRoom(RoomEntryViewController vc, int idx)
+        {
+            var list = vc.dataList;
+            if (list == null || idx < 0 || idx >= list.Count) return null;
+
+            var data = list[idx];
+            if (data == null) return null;
+
+            var parts = new List<string>(5);
+            string name = data.name?.Trim();
+            parts.Add(string.IsNullOrEmpty(name) ? "Unnamed room" : name);
+
+            string regulation = data.regulation?.Trim();
+            if (!string.IsNullOrEmpty(regulation))
+                parts.Add(regulation);
+
+            if (data.memberMax > 0)
+                parts.Add($"{data.memberNum} of {data.memberMax} members");
+
+            string endDate = data.endDate?.Trim();
+            if (!string.IsNullOrEmpty(endDate))
+                parts.Add(endDate.StartsWith("Until", StringComparison.OrdinalIgnoreCase) ? endDate : $"until {endDate}");
+
+            int total = list.Count;
+            if (total > 1)
+                parts.Add($"{idx + 1} of {total}");
+
+            return string.Join(", ", parts);
+        }
+
+        private static RoomEntryViewController GetVC()
+        {
+            try { return ScreenDetector.GetFocusVC()?.TryCast<RoomEntryViewController>(); }
+            catch { return null; }
+        }
+    }
+}

--- a/Handlers/RoomHandler.cs
+++ b/Handlers/RoomHandler.cs
@@ -1,0 +1,376 @@
+using System;
+using Il2CppYgomGame.Room;
+using Il2CppYgomSystem.UI;
+using UnityEngine;
+
+namespace BlindDuel
+{
+    public class RoomHandler : IMenuHandler
+    {
+        private static int _lastMembers = -1;
+        private static int _lastSpecters = -1;
+
+        // Flat per-seat layout: index 2*i = left seat of table i, 2*i+1 = right seat.
+        private static long[] _seatPcodes = System.Array.Empty<long>();
+        private static string[] _seatNames = System.Array.Empty<string>();
+
+        public bool CanHandle(string viewControllerName) => viewControllerName == "Room";
+
+        public bool OnScreenEntered(string viewControllerName)
+        {
+            _lastMembers = -1;
+            _lastSpecters = -1;
+            _seatPcodes = System.Array.Empty<long>();
+            _seatNames = System.Array.Empty<string>();
+            Speech.AnnounceScreen(BuildScreenAnnouncement());
+            return true;
+        }
+
+        public static void Poll()
+        {
+            try
+            {
+                if (HandlerRegistry.Current is not RoomHandler)
+                {
+                    _lastMembers = -1;
+                    _lastSpecters = -1;
+                    _seatPcodes = System.Array.Empty<long>();
+                    _seatNames = System.Array.Empty<string>();
+                    return;
+                }
+
+                var vc = GetRoomVC();
+                var info = vc?.roomBehaviour?.roomInfo;
+                if (info == null) return;
+
+                ForceDisableCommentButtons(vc);
+
+                int members = info.memberNum;
+                int max = info.memberMax;
+                int specters = info.specterNum;
+
+                if (_lastMembers < 0)
+                {
+                    _lastMembers = members;
+                    _lastSpecters = specters;
+                    return;
+                }
+
+                if (members != _lastMembers)
+                {
+                    string verb = members > _lastMembers ? "joined" : "left";
+                    _lastMembers = members;
+                    Speech.SayImmediate(max > 0
+                        ? $"Player {verb}, {members} of {max} members"
+                        : $"Player {verb}, {members} members");
+                }
+
+                if (specters != _lastSpecters)
+                {
+                    int diff = specters - _lastSpecters;
+                    _lastSpecters = specters;
+                    Speech.SayImmediate(diff > 0
+                        ? $"Spectator joined, {specters} watching"
+                        : $"Spectator left, {specters} watching");
+                }
+
+                var tables = vc.roomBehaviour?.tableDataList;
+                if (tables == null) return;
+                int seatCount = tables.Count * 2;
+
+                // Snapshot without announcing on the first poll (or after table-count change).
+                if (_seatPcodes.Length != seatCount)
+                {
+                    _seatPcodes = new long[seatCount];
+                    _seatNames = new string[seatCount];
+                    for (int i = 0; i < tables.Count; i++)
+                    {
+                        var t = tables[i];
+                        var (lp, ln) = ReadSeat(t?.members, 0);
+                        var (rp, rn) = ReadSeat(t?.members, 1);
+                        _seatPcodes[2 * i] = lp; _seatNames[2 * i] = ln;
+                        _seatPcodes[2 * i + 1] = rp; _seatNames[2 * i + 1] = rn;
+                    }
+                    return;
+                }
+
+                for (int i = 0; i < tables.Count; i++)
+                {
+                    var t = tables[i];
+                    if (t == null) continue;
+                    AnnounceSeatChange(i + 1, "left",  2 * i,     t.members, 0);
+                    AnnounceSeatChange(i + 1, "right", 2 * i + 1, t.members, 1);
+                }
+            }
+            catch { }
+        }
+
+        private static (long pcode, string name) ReadSeat(
+            Il2CppInterop.Runtime.InteropTypes.Arrays.Il2CppReferenceArray<RoomViewController.RoomBehaviour.MemberData> members,
+            int slot)
+        {
+            try
+            {
+                if (members == null || slot < 0 || slot >= members.Length) return (0, null);
+                var m = members[slot];
+                if (m == null) return (0, null);
+                long pcode = m.pcode;
+                if (pcode <= 0) return (0, null);
+                string name = m.name?.Trim();
+                return (pcode, string.IsNullOrWhiteSpace(name) ? null : name);
+            }
+            catch { return (0, null); }
+        }
+
+        private static void AnnounceSeatChange(
+            int tableNum, string side, int stateIdx,
+            Il2CppInterop.Runtime.InteropTypes.Arrays.Il2CppReferenceArray<RoomViewController.RoomBehaviour.MemberData> members,
+            int slot)
+        {
+            var (pcode, name) = ReadSeat(members, slot);
+            if (pcode == _seatPcodes[stateIdx]) return;
+
+            if (pcode > 0)
+                Speech.SayImmediate($"{name ?? "A player"} sat at Table {tableNum}, {side} seat");
+            else
+                Speech.SayImmediate($"{_seatNames[stateIdx] ?? "A player"} left Table {tableNum}, {side} seat");
+
+            _seatPcodes[stateIdx] = pcode;
+            _seatNames[stateIdx] = name;
+        }
+
+        private static string BuildScreenAnnouncement()
+        {
+            string header = ScreenDetector.ReadGameHeaderText();
+            string fallback = !string.IsNullOrWhiteSpace(header) ? header : "Duel Room";
+
+            try
+            {
+                var info = GetRoomVC()?.roomBehaviour?.roomInfo;
+                if (info == null) return fallback;
+
+                string name = info.roomName?.Trim();
+                string regulation = info.regulation?.Trim();
+                int members = info.memberNum;
+                int max = info.memberMax;
+                int specters = info.specterNum;
+
+                string result = !string.IsNullOrWhiteSpace(name) ? name : fallback;
+                if (!string.IsNullOrWhiteSpace(regulation))
+                    result += $", {regulation}";
+                if (max > 0)
+                    result += $", {members} of {max} members";
+                if (specters > 0)
+                    result += $", {specters} watching";
+
+                return result;
+            }
+            catch (Exception ex)
+            {
+                Log.Write($"[RoomHandler] Screen error: {ex.Message}");
+                return fallback;
+            }
+        }
+
+        public string OnButtonFocused(SelectionButton button)
+        {
+            try
+            {
+                var vc = GetRoomVC();
+                if (vc != null && TryGetTableIndex(vc, button, out int tableIdx))
+                    return HandleTableRow(vc, tableIdx, button.name);
+
+                if (button.name == "ButtonDeck")
+                    return HandleDeckButton(button);
+
+                return HandleMenuButton(button);
+            }
+            catch (Exception ex)
+            {
+                Log.Write($"[RoomHandler] Button error: {ex.Message}");
+                return null;
+            }
+        }
+
+        // Keep ButtonCommentLeft/Right deactivated: their picker dialog (Table Comments
+        // ActionSheet) has a game-side off-by-one between visible entry and click target,
+        // so we hide the entry point. Reading others' comments via "says X" still works.
+        private static void ForceDisableCommentButtons(RoomViewController vc)
+        {
+            try
+            {
+                if (vc == null) return;
+                var sbs = vc.gameObject.GetComponentsInChildren<SelectionButton>(true);
+                if (sbs == null) return;
+                foreach (var sb in sbs)
+                {
+                    if (sb == null || sb.WasCollected) continue;
+                    if ((sb.name == "ButtonCommentLeft" || sb.name == "ButtonCommentRight")
+                        && sb.gameObject.activeSelf)
+                    {
+                        sb.gameObject.SetActive(false);
+                    }
+                }
+            }
+            catch (Exception ex) { Log.Write($"[RoomHandler] ForceDisableCommentButtons: {ex.Message}"); }
+        }
+
+        private static bool TryGetTableIndex(RoomViewController vc, SelectionButton button, out int idx)
+        {
+            idx = -1;
+            try
+            {
+                var isv = vc.isv;
+                if (isv == null) return false;
+
+                Transform t = button.transform;
+                for (int i = 0; i < 8 && t != null; i++)
+                {
+                    try
+                    {
+                        int candidate = isv.GetDataIndexByEntity(t.gameObject);
+                        if (candidate >= 0) { idx = candidate; return true; }
+                    }
+                    catch { }
+                    t = t.parent;
+                }
+            }
+            catch { }
+            return false;
+        }
+
+        private static string HandleTableRow(RoomViewController vc, int idx, string buttonName)
+        {
+            var rb = vc.roomBehaviour;
+            var list = rb?.tableDataList;
+            if (list == null || idx < 0 || idx >= list.Count) return null;
+
+            var table = list[idx];
+            if (table == null) return null;
+
+            int total = list.Count;
+            int tableNum = idx + 1;
+            var comments = rb._tableComments;
+
+            if (buttonName == "ButtonLeave")
+                return $"Leave Table {tableNum}";
+
+            string result = $"Table {tableNum}";
+
+            var (leftName, leftComment) = GetSeatInfo(table.members, 0, comments);
+            var (rightName, rightComment) = GetSeatInfo(table.members, 1, comments);
+
+            if (leftName == null && rightName == null)
+            {
+                result += ", empty";
+            }
+            else
+            {
+                if (leftName != null)
+                {
+                    result += $", left: {leftName}";
+                    if (leftComment != null) result += $", says {leftComment}";
+                }
+                else result += ", left empty";
+
+                if (rightName != null)
+                {
+                    result += $", right: {rightName}";
+                    if (rightComment != null) result += $", says {rightComment}";
+                }
+                else result += ", right empty";
+            }
+
+            string status = StatusText(table.status);
+            if (!string.IsNullOrEmpty(status))
+                result += $", {status}";
+
+            try
+            {
+                if (table.myPlayerEntry)
+                    result += ", you are here";
+            }
+            catch { }
+
+            if (total > 1)
+                result += $", {tableNum} of {total}";
+
+            return result;
+        }
+
+        private static (string name, string comment) GetSeatInfo(
+            Il2CppInterop.Runtime.InteropTypes.Arrays.Il2CppReferenceArray<RoomViewController.RoomBehaviour.MemberData> members,
+            int slot,
+            Il2CppInterop.Runtime.InteropTypes.Arrays.Il2CppStringArray comments)
+        {
+            try
+            {
+                if (members == null || slot < 0 || slot >= members.Length) return (null, null);
+                var m = members[slot];
+                if (m == null || m.pcode <= 0) return (null, null);
+
+                string name = m.name?.Trim();
+                if (string.IsNullOrWhiteSpace(name)) name = null;
+
+                string comment = null;
+                int cid = m.commentID;
+                if (comments != null && cid > 0 && cid < comments.Length)
+                {
+                    string c = comments[cid]?.Trim();
+                    if (!string.IsNullOrWhiteSpace(c)) comment = c;
+                }
+                return (name, comment);
+            }
+            catch { return (null, null); }
+        }
+
+        private static string StatusText(RoomViewController.RoomBehaviour.TableStatus s) => s switch
+        {
+            RoomViewController.RoomBehaviour.TableStatus.WAIT => "waiting",
+            RoomViewController.RoomBehaviour.TableStatus.READY_LEFT => "left player ready",
+            RoomViewController.RoomBehaviour.TableStatus.READY_RIGHT => "right player ready",
+            RoomViewController.RoomBehaviour.TableStatus.DUEL => "dueling",
+            RoomViewController.RoomBehaviour.TableStatus.SPECTATE => "spectator only",
+            _ => null,
+        };
+
+        private static string HandleDeckButton(SelectionButton button)
+        {
+            string text = TextExtractor.ExtractFirst(button.gameObject);
+            if (string.IsNullOrWhiteSpace(text)) return "Deck";
+            return $"Deck, {text}";
+        }
+
+        private static string HandleMenuButton(SelectionButton button)
+        {
+            string text = TextExtractor.ExtractFirst(button.gameObject);
+            if (string.IsNullOrWhiteSpace(text)) return null;
+
+            var current = button.transform.parent;
+            while (current != null)
+            {
+                int idx = 0, total = 0;
+                for (int i = 0; i < current.childCount; i++)
+                {
+                    var child = current.GetChild(i);
+                    if (child == null || !child.gameObject.activeInHierarchy) continue;
+                    var sb = child.GetComponentInChildren<SelectionButton>(true);
+                    if (sb == null) continue;
+                    total++;
+                    if (sb == button) idx = total;
+                }
+                if (total > 1 && idx > 0)
+                    return $"{text}, {idx} of {total}";
+
+                current = current.parent;
+            }
+            return text;
+        }
+
+        private static RoomViewController GetRoomVC()
+        {
+            try { return ScreenDetector.GetFocusVC()?.TryCast<RoomViewController>(); }
+            catch { return null; }
+        }
+    }
+}

--- a/Handlers/RoomInviteHandler.cs
+++ b/Handlers/RoomInviteHandler.cs
@@ -1,0 +1,194 @@
+using System;
+using Il2CppYgomGame.Friend;
+using Il2CppYgomGame.Room;
+using Il2CppYgomSystem.UI;
+using UnityEngine;
+
+namespace BlindDuel
+{
+    public class RoomInviteHandler : IMenuHandler
+    {
+        private static int _lastSelectedCount = -1;
+        private static int _lastMax = -1;
+
+        // dataList is populated async; at screen entry an empty list might just be
+        // loading. Wait this many frames (~1.5s at 60fps) before announcing "empty".
+        private const int EmptyGraceFrames = 90;
+        private static int _emptyFrameCount;
+        private static bool _emptyAnnounced;
+
+        public bool CanHandle(string viewControllerName) => viewControllerName == "RoomInvite";
+
+        public bool OnScreenEntered(string viewControllerName)
+        {
+            _lastSelectedCount = -1;
+            _lastMax = -1;
+            _emptyFrameCount = 0;
+            _emptyAnnounced = false;
+
+            string header = ScreenDetector.ReadGameHeaderText();
+            string announcement = !string.IsNullOrWhiteSpace(header) ? header : "Invite Friends";
+
+            try
+            {
+                var vc = GetVC();
+                if (vc != null && vc.maxInvite > 0)
+                {
+                    announcement += $", {vc.currentInvite} of {vc.maxInvite} selected";
+                    _lastSelectedCount = vc.currentInvite;
+                    _lastMax = vc.maxInvite;
+                }
+            }
+            catch (Exception ex) { Log.Write($"[RoomInviteHandler] Screen error: {ex.Message}"); }
+
+            Speech.AnnounceScreen(announcement);
+            return true;
+        }
+
+        public string OnButtonFocused(SelectionButton button)
+        {
+            try
+            {
+                var vc = GetVC();
+                if (vc == null) return null;
+
+                if (TryGetFocusedRow(vc, button, out var widget, out var rowGo))
+                    return FormatFriendRow(vc, widget, rowGo);
+            }
+            catch (Exception ex)
+            {
+                Log.Write($"[RoomInviteHandler] Button error: {ex.Message}");
+            }
+            return null;
+        }
+
+        // Toggling a friend row updates currentInvite without firing a screen change,
+        // so we re-announce the new count here when it shifts.
+        public static void Poll()
+        {
+            try
+            {
+                if (HandlerRegistry.Current is not RoomInviteHandler)
+                {
+                    _lastSelectedCount = -1;
+                    _emptyFrameCount = 0;
+                    _emptyAnnounced = false;
+                    return;
+                }
+
+                var vc = GetVC();
+                if (vc == null) return;
+
+                var list = vc.dataList;
+                bool listEmpty = (list == null || list.Count == 0);
+
+                if (listEmpty)
+                {
+                    if (!_emptyAnnounced)
+                    {
+                        _emptyFrameCount++;
+                        if (_emptyFrameCount >= EmptyGraceFrames)
+                        {
+                            Speech.SayQueued("No friends available to invite");
+                            _emptyAnnounced = true;
+                        }
+                    }
+                    return;
+                }
+
+                _emptyFrameCount = 0;
+
+                int count = vc.currentInvite;
+                int max = vc.maxInvite;
+
+                if (_lastSelectedCount < 0)
+                {
+                    _lastSelectedCount = count;
+                    _lastMax = max;
+                }
+                else if (count != _lastSelectedCount || max != _lastMax)
+                {
+                    _lastSelectedCount = count;
+                    _lastMax = max;
+                    Speech.SayImmediate(max > 0 ? $"{count} of {max} selected" : $"{count} selected");
+                }
+            }
+            catch { }
+        }
+
+        private static bool TryGetFocusedRow(
+            RoomInviteViewController vc, SelectionButton button,
+            out FriendWidget widget, out GameObject rowGo)
+        {
+            widget = null;
+            rowGo = null;
+
+            var map = vc.m_EntityWidgetMap;
+            if (map == null) return false;
+
+            Transform t = button.transform;
+            for (int i = 0; i < 6 && t != null; i++)
+            {
+                if (map.TryGetValue(t.gameObject, out var w))
+                {
+                    widget = w;
+                    rowGo = t.gameObject;
+                    return true;
+                }
+                t = t.parent;
+            }
+            return false;
+        }
+
+        private static string FormatFriendRow(
+            RoomInviteViewController vc, FriendWidget widget, GameObject rowGo)
+        {
+            string name = null;
+            try
+            {
+                var group = widget.platformPlayerNameGroup;
+                if (group != null) name = group.GetYmdPlayerName();
+            }
+            catch { }
+            if (string.IsNullOrWhiteSpace(name)) return null;
+
+            int idx = -1;
+            try { idx = vc.isv?.GetDataIndexByEntity(rowGo) ?? -1; } catch { }
+
+            bool? online = null;
+            bool? selected = null;
+            int total = 0;
+            try
+            {
+                var list = vc.dataList;
+                if (list != null)
+                {
+                    total = list.Count;
+                    if (idx >= 0 && idx < total)
+                    {
+                        var data = list[idx];
+                        online = data.isOnline;
+                        selected = data.isSelected;
+                    }
+                }
+            }
+            catch { }
+
+            string result = name;
+            if (online.HasValue)
+                result += online.Value ? ", online" : ", offline";
+            if (selected == true)
+                result += ", selected";
+            if (idx >= 0 && total > 1)
+                result += $", {idx + 1} of {total}";
+
+            return result;
+        }
+
+        private static RoomInviteViewController GetVC()
+        {
+            try { return ScreenDetector.GetFocusVC()?.TryCast<RoomInviteViewController>(); }
+            catch { return null; }
+        }
+    }
+}

--- a/Patches/ButtonPatches.cs
+++ b/Patches/ButtonPatches.cs
@@ -255,6 +255,12 @@ namespace BlindDuel
             if (string.IsNullOrWhiteSpace(text))
                 text = FindSiblingText(__instance.transform) ?? text;
 
+            // InputDigit dialog +/- buttons: replace the symbolic "-" / "＋" label
+            // with a spoken word so the screen reader doesn't fuse it with the
+            // sibling-index suffix into a misleading negative number.
+            string digitLabel = InputDigitWatcher.GetButtonLabel(__instance);
+            if (digitLabel != null) text = digitLabel;
+
             // Let the active handler enhance the text
             string enhanced = null;
             var handler = HandlerRegistry.Current;

--- a/UI/ElementReader.cs
+++ b/UI/ElementReader.cs
@@ -143,6 +143,28 @@ namespace BlindDuel
             return (title, body);
         }
 
+        // Heuristic for "this text is the label of an action button, not body content":
+        // short single token, no lowercase letters, at least one uppercase letter.
+        // Catches OK / CANCEL / YES / NO / AGREE / etc. while leaving numbers, dates,
+        // and any mixed-case text intact. Callers should only apply this where the
+        // focused button will speak its own label separately (i.e. dialogs).
+        public static bool LooksLikeButtonText(string text)
+        {
+            if (string.IsNullOrEmpty(text) || text.Length > 10) return false;
+            bool sawUpper = false;
+            for (int i = 0; i < text.Length; i++)
+            {
+                char c = text[i];
+                if (char.IsWhiteSpace(c)) return false;
+                if (char.IsLetter(c))
+                {
+                    if (!char.IsUpper(c)) return false;
+                    sawUpper = true;
+                }
+            }
+            return sawUpper;
+        }
+
         /// <summary>
         /// Detect placeholder text (unreplaced key names — long strings with no spaces).
         /// </summary>


### PR DESCRIPTION
## Summary
- Four new screen handlers covering the Duel Room flow:
  - `RoomHandler` — duel room screen: room name + regulation + member count in the header; per-table row reads occupants/status/comment; live polling announces member, spectator, and seat-occupancy changes.
  - `RoomCreateHandler` — create-room settings: each row reads "Title, Value"; ON/OFF flips re-announced in place.
  - `RoomInviteHandler` — friend invite list: row reads name + online/offline + selected; selection-count change announced; empty-state detected after async load.
  - `RoomEntryHandler` — room browser: "Room List, N rooms" on entry; each row reads name, regulation, member count, end date.
- New `InputDigitWatcher` (Detection/) — generic watcher for the +/- numeric picker dialog (Room Max Occupancy and similar). Announces the current value live as buttons are pressed, and substitutes verbal labels ("minus 1", "plus 10") for the symbolic +/- buttons so screen readers don't fuse "-" with the trailing index suffix into a misleading number.
- Dialog accessibility fixes in shared helpers:
  - `Speech.ResetHeaderDedup()` + `DialogDetector` now clears the screen header dedup when a dialog truly closes — previously, opening the same dialog (e.g. "Room is at full capacity") twice in a row silently suppressed the second announcement.
  - `ElementReader.LooksLikeButtonText` filters short all-caps labels (OK / CANCEL / YES / NO / AGREE) out of dialog body text, since the focused button speaks its own label separately right after.
